### PR TITLE
Fix scikit-learn install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here's the result:
 - Python 3.x
 - pandas library (can be installed via `pip install pandas`)
 - numpy library (can be installed via `pip install numpy`)
-- sklearn library (can be installed via `pip install scikitlearn`)
+- sklearn library (can be installed via `pip install scikit-learn`)
 - matplotlib library (can be installed via `pip install matplotlib`)
 
 


### PR DESCRIPTION
## Summary
- correct package name in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68483ff9606483268f56198fecf78003